### PR TITLE
Add a sketch of the payment plan idea

### DIFF
--- a/aiken.lock
+++ b/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1700966727, nanos_since_epoch = 192028417 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1706754456, nanos_since_epoch = 189704959 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/lib/sundae/payments.ak
+++ b/lib/sundae/payments.ak
@@ -1,0 +1,94 @@
+use aiken/dict.{Dict}
+use aiken/list
+use aiken/transaction.{ValidityRange, Output}
+use aiken/interval.{Finite}
+use aiken/transaction/credential.{Address, StakeCredential, Script, Inline, ScriptCredential}
+use aiken/transaction/value
+use aiken/hash.{Hash, Blake2b_224}
+use aiken/time.{PosixTime}
+use sundae/multisig
+
+pub type ScheduleEntry {
+    date: PosixTime,
+    amount: Int,
+}
+
+pub type Schedule {
+    Recurring { start: PosixTime, interval: Int, amount: Int, end: PosixTime }
+    Structured { phases: List<ScheduleEntry> }
+}
+
+pub type PaymentPlan {
+    owner: multisig.MultisigScript,
+    recipient: Address,
+    condition: Option<ByteArray>,
+    fee: Int,
+    schedule: Schedule,
+}
+
+fn condition_satisfied(condition: Option<ByteArray>, withdrawals: Dict<StakeCredential, Int>) -> Bool {
+    when condition is {
+        None -> True
+        Some(cond) -> {
+            dict.has_key(withdrawals, Inline(ScriptCredential(cond)))
+        }
+    }
+}
+
+fn get_bounds(valid_range: ValidityRange) -> (PosixTime, PosixTime) {
+    expect Finite(lo) = valid_range.lower_bound.bound_type
+    expect Finite(hi) = valid_range.upper_bound.bound_type
+    (lo, hi)
+}
+
+//
+//
+//  DISCLAIMER:
+//  This is currently a sketch of an idea, and is not safe to use in production until it's been refined more.
+//  In particular, it's currently vulnerable to double-satisfaction and all manner of things
+//
+
+pub fn satisfied(
+    own_script_hash: Hash<Blake2b_224, Script>,
+    plan: PaymentPlan,
+    signatories: List<ByteArray>,
+    valid_range: ValidityRange,
+    withdrawals: Dict<StakeCredential, Int>,
+    utxo: Output,
+    outputs: List<Output>,
+) -> Bool {
+    // If they've attached some extra condition, make sure it is satisfied
+    expect condition_satisfied(plan.condition, withdrawals)
+
+    // Calculate the amount that is still owned by the owner, and the amount that is now owned by the recipient
+    let (lo, hi) = get_bounds(valid_range)
+    expect hi - lo <= 60 * 60 * 1000 // tx validity range must be within one hour, so we can rely on the time
+    let (owned, sent) = when plan.schedule is {
+        Recurring { start, interval, amount, end } -> {
+            let periods = (hi - start) / interval
+            if hi <= start {
+                (value.lovelace_of(utxo.value), 0)
+            } else if lo >= end {
+                (0, amount * periods)
+            } else {
+                let sent = amount * periods
+                let owned = value.lovelace_of(utxo.value) - sent
+                (owned, sent)
+            }
+        }
+        Structured { phases } -> {
+            let sent = list.foldl(phases, 0, fn(p, total) { if hi >= p.date { total + p.amount } else { total } })
+            let owned = value.lovelace_of(utxo.value) - sent
+            (owned, sent)
+        }
+    }
+    // make sure the amount sent to recipient is at least the amount that has been unlocked so far
+    let recipient_amount = list.foldl(outputs, 0, fn(o, total) { if o.address == plan.recipient { total + value.lovelace_of(o.value) } else { total } })
+    expect recipient_amount >= sent
+    // and at least the remainder (minus a fee) must be sent back to the script, or the owner has to sign the tx
+    expect [output] = list.filter(outputs, fn(o) { o.address.payment_credential == ScriptCredential(own_script_hash) })
+    or {
+        multisig.satisfied(plan.owner, signatories, valid_range, withdrawals),
+        value.lovelace_of(output.value) >= owned - plan.fee
+    }
+}

--- a/lib/sundae/payments.ak
+++ b/lib/sundae/payments.ak
@@ -87,6 +87,7 @@ pub fn satisfied(
     expect recipient_amount >= sent
     // and at least the remainder (minus a fee) must be sent back to the script, or the owner has to sign the tx
     expect [output] = list.filter(outputs, fn(o) { o.address.payment_credential == ScriptCredential(own_script_hash) })
+    expect output.datum == utxo.datum
     or {
         multisig.satisfied(plan.owner, signatories, valid_range, withdrawals),
         value.lovelace_of(output.value) >= owned - plan.fee


### PR DESCRIPTION
This adds a basic payment plan script.

Payment plans are intended to mediate some regular release of funds to a recipient.

They can be owned by a sundae multisig, meaning they can be owned by a single user, a multisig address, or even a script.

They can be either:
  - a recurring payment, with a start, end, an interval, and an amount to release each interval
  - a structured payment, with a series of payouts

A payment plan can also have additional conditions attached; this is a script that must be in the withdrawals, and can enforce that, for example, an NFT be paid to a specific address, or that a third party mediator has certified the work, etc.

It's provided as a function, instead of a validator, so that it can compose as just a component of other larger protocols.

And, if the fee is set greater than 0, it allows a portion of the payment to be shaved off by a payment processor, if you want to incentivize the payout to actually get processed.

**DISCLAIMER**: **This is just a sketch of an idea; I haven't checked this for correctness, audited it, or even tested it.** In particular, I know it's vulnerable to multi-satisfaction (pull requests welcome!). I just wanted to sketch the idea out for a twitter thread.