### PR TITLE
Add a stake rights splitting script

### DIFF
--- a/validators/stakerights.ak
+++ b/validators/stakerights.ak
@@ -1,0 +1,25 @@
+use aiken/list
+use aiken/transaction.{ScriptContext, WithdrawFrom, Publish}
+use aiken/transaction/certificate.{CredentialRegistration, CredentialDeregistration, CredentialDelegation}
+
+validator(owner: ByteArray, delegator: ByteArray) {
+    fn stake(_r: Data, ctx: ScriptContext) -> Bool {
+        when ctx.purpose is {
+            WithdrawFrom(_) -> {
+                list.has(ctx.transaction.extra_signatories, owner)
+            }
+            Publish(cert) -> {
+                when cert is {
+                    CredentialRegistration(_) | CredentialDeregistration(_) -> {
+                        list.has(ctx.transaction.extra_signatories, owner)
+                    }
+                    CredentialDelegation(_, _) -> {
+                        list.has(ctx.transaction.extra_signatories, delegator)
+                    }
+                    _ -> False
+                }
+            }
+            _ -> False
+        }
+    }
+}


### PR DESCRIPTION
Adds a small POC validator that separates the owner of a stake address (who receives rewards and can reclaim the deposit) and the delegator (who *only* controls the delegation capabilities. This could be used for a cold/hot wallet setup, for example.

Implemented to answer [Mauro Andreoli](https://x.com/MauroAndreoliA)'s question of whether it were possible.