### PR TITLE
Add satisfies_payload

### DIFF
--- a/aiken.lock
+++ b/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1725037798, nanos_since_epoch = 785052000 }, "40b240a5f019f5f699fbae0a3eb2f2b0a31741a635f0914b5ba61538701c6a40"]
+"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1726186674, nanos_since_epoch = 490381000 }, "d79382d2b6ecb3aee9b0755c31d8a5bbafe88a7b3706d7fb8a52fd4d05818501"]

--- a/lib/sundae/multisig.ak
+++ b/lib/sundae/multisig.ak
@@ -1,5 +1,8 @@
 use aiken/collection/list
 use aiken/collection/pairs
+use aiken/crypto.{
+  Signature, VerificationKey, blake2b_224, verify_ed25519_signature,
+}
 use aiken/interval.{Finite, Interval, IntervalBound}
 use cardano/address.{Credential}
 use cardano/assets.{Lovelace}
@@ -38,29 +41,92 @@ pub fn satisfied(
         scripts,
         fn(s) { satisfied(s, signatories, valid_range, withdrawals) },
       )
-    // TODO: could be simplified with https://github.com/aiken-lang/aiken/issues/566
     Before { time } ->
-      when valid_range.upper_bound.bound_type is {
-        Finite(hi) ->
-          if valid_range.upper_bound.is_inclusive {
-            hi <= time
-          } else {
-            hi < time
-          }
+      when valid_range.upper_bound is {
+        IntervalBound { bound_type: Finite(hi), is_inclusive: True } ->
+          hi <= time
+        IntervalBound { bound_type: Finite(hi), is_inclusive: False } ->
+          hi < time
         _ -> False
       }
     After { time } ->
-      when valid_range.lower_bound.bound_type is {
-        Finite(lo) ->
-          if valid_range.lower_bound.is_inclusive {
-            time <= lo
-          } else {
-            time < lo
-          }
+      when valid_range.lower_bound is {
+        IntervalBound { bound_type: Finite(lo), is_inclusive: True } ->
+          time <= lo
+        IntervalBound { bound_type: Finite(lo), is_inclusive: False } ->
+          time < lo
         _ -> False
       }
     Script { script_hash } ->
       pairs.has_key(withdrawals, address.Script(script_hash))
+  }
+}
+
+pub fn satisfied_payload(
+  script: MultisigScript,
+  payload: ByteArray,
+  signatures: List<(VerificationKey, Signature)>,
+  valid_range: ValidityRange,
+  withdrawals: Pairs<Credential, Lovelace>,
+) -> Bool {
+  when script is {
+    Signature { key_hash } -> {
+      expect Some((public_key, signature)) =
+        list.find(signatures, fn((k, _)) { blake2b_224(k) == key_hash })
+      verify_ed25519_signature(public_key, payload, signature)
+    }
+    AllOf { scripts } ->
+      list.all(
+        scripts,
+        fn(s) {
+          satisfied_payload(s, payload, signatures, valid_range, withdrawals)
+        },
+      )
+    AnyOf { scripts } ->
+      list.any(
+        scripts,
+        fn(s) {
+          satisfied_payload(s, payload, signatures, valid_range, withdrawals)
+        },
+      )
+    AtLeast { required, scripts } ->
+      required <= list.count(
+        scripts,
+        fn(s) {
+          satisfied_payload(s, payload, signatures, valid_range, withdrawals)
+        },
+      )
+    Before { time } ->
+      when valid_range.upper_bound is {
+        IntervalBound { bound_type: Finite(hi), is_inclusive: True } ->
+          hi <= time
+        IntervalBound { bound_type: Finite(hi), is_inclusive: False } ->
+          hi < time
+        _ -> False
+      }
+    After { time } ->
+      when valid_range.lower_bound is {
+        IntervalBound { bound_type: Finite(lo), is_inclusive: True } ->
+          time <= lo
+        IntervalBound { bound_type: Finite(lo), is_inclusive: False } ->
+          time < lo
+        _ -> False
+      }
+    Script { script_hash } ->
+      pairs.has_key(withdrawals, address.Script(script_hash))
+  }
+}
+
+fn valid_range(lo: Int, hi: Int) -> ValidityRange {
+  Interval {
+    lower_bound: IntervalBound {
+      bound_type: Finite(lo),
+      is_inclusive: True,
+    },
+    upper_bound: IntervalBound {
+      bound_type: Finite(hi),
+      is_inclusive: False,
+    },
   }
 }
 
@@ -97,20 +163,6 @@ test satisfying() {
       ],
     }
   trace @"Vesting": vesting
-  // vested
-  let valid_range =
-    fn(lo: Int, hi: Int) -> ValidityRange {
-      Interval {
-        lower_bound: IntervalBound {
-          bound_type: Finite(lo),
-          is_inclusive: True,
-        },
-        upper_bound: IntervalBound {
-          bound_type: Finite(hi),
-          is_inclusive: False,
-        },
-      }
-    }
   let no_w: Pairs<Credential, Lovelace> =
     []
   let correct_w =
@@ -173,4 +225,20 @@ test satisfying() {
     ],
     fn(n) { n },
   )
+}
+
+test satisfying_payload() {
+  let payload = "some_payload"
+  // Generated from seed "E5C6E8D39E443DC0A2845BB13217070EE2D82E7C1BE580DA22E7C6BF2DB56EA9"
+  // here: https://cyphr.me/ed25519_tool/ed.html
+  let key1 = #"BECFF931D5043DB380B78F5B1BA79D549999024C5FC0C9DD9390DA0D12B054BC"
+  let key_hash1 = blake2b_224(key1)
+  let sig1 = Signature { key_hash: key_hash1 }
+  let signature = #"BDA2210A08762FC1032523653F32D57CC97BFBAF84C46566625F4240C3AD59D3D2EFC7A1D1640CF79E4D337368595E7BDCE92AF6EA0C3278C2998482B8DD7D05"
+  let wrong_signature = #"CDA2210A08762FC1032523653F32D57CC97BFBAF84C46566625F4240C3AD59D3D2EFC7A1D1640CF79E4D337368595E7BDCE92AF6EA0C3278C2998482B8DD7D05"
+  let no_w: Pairs<Credential, Lovelace> = []
+  and {
+    satisfied_payload(sig1, payload, [(key1, signature)], valid_range(0,1), no_w),
+    !satisfied_payload(sig1, payload, [(key1, wrong_signature)], valid_range(0,1), no_w),
+  }
 }


### PR DESCRIPTION
This variant lets you pass in the payload explicitly, in case you're not validating a transaction but instead are validating signatures on a redeemer, for example