### PR TITLE
Use bytestring headers and definite-length encoding

### DIFF
--- a/aiken.lock
+++ b/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1767872853, nanos_since_epoch = 964421175 }, "6928535a4098118e5f2a30478caf80defeec5e128b4768da88c97399bb563b6d"]
+"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1768154829, nanos_since_epoch = 746587442 }, "6928535a4098118e5f2a30478caf80defeec5e128b4768da88c97399bb563b6d"]

--- a/lib/sundae/cose.ak
+++ b/lib/sundae/cose.ak
@@ -1,17 +1,13 @@
 use aiken/builtin
 use aiken/cbor
-use aiken/collection/list
-use aiken/collection/pairs
 use aiken/crypto
 use aiken/option
-
-pub const hdr_key_id: Data = 4
 
 pub type COSESignatures =
   List<COSESignature>
 
 pub type HeaderMap =
-  Pairs<Data, Data>
+  ByteArray
 
 pub type Headers {
   protected: HeaderMap,
@@ -53,15 +49,9 @@ pub fn data_to_sign(
 ) -> SigStructure {
   let headers = headers(signed_message)
 
-  let body_protected =
-    if list.length(headers.protected) > 0 {
-      cbor.serialise(headers.protected)
-    } else {
-      #""
-    }
   SigStructure {
     context: context(signed_message),
-    body_protected,
+    body_protected: headers.protected,
     external_aad: option.or_else(external_aad, #""),
     payload: payload(signed_message),
   }
@@ -89,6 +79,11 @@ pub fn payload(signed_message: SignedMessage) -> ByteArray {
 }
 
 pub fn serialise_sig_structure(sig_structure: SigStructure) -> ByteArray {
+  trace @"SigStructure.context": sig_structure.context
+  trace @"SigStructure.body_protected": sig_structure.body_protected
+  trace @"SigStructure.external_aad": sig_structure.external_aad
+  trace @"SigStructure.payload": sig_structure.payload
+
   let raw_bytes =
     cbor.serialise(
       [
@@ -98,6 +93,7 @@ pub fn serialise_sig_structure(sig_structure: SigStructure) -> ByteArray {
         sig_structure.payload,
       ],
     )
+  trace @"raw_bytes (CBOR serialised)": raw_bytes
 
   let context_type_byte = builtin.slice_bytearray(1, 1, raw_bytes)
   let fixed_content_type_byte = builtin.write_bits(context_type_byte, [5], True)
@@ -108,40 +104,13 @@ pub fn serialise_sig_structure(sig_structure: SigStructure) -> ByteArray {
       raw_bytes,
     )
 
-  builtin.append_bytearray(
-    #"84",
-    builtin.append_bytearray(fixed_content_type_byte, content_bytes),
-  )
-}
-
-pub fn extract_signatures(
-  signed_message: SignedMessage,
-) -> List<(crypto.VerificationKey, crypto.Signature)> {
-  when signed_message is {
-    SingleSig(cose_sign1) ->
-      when pairs.get_first(cose_sign1.headers.protected, hdr_key_id) is {
-        Some(key_data) -> {
-          expect key_bytes: crypto.VerificationKey = key_data
-          [(key_bytes, cose_sign1.signature)]
-        }
-        None -> []
-      }
-    MultiSig(cose_sign) ->
-      list.flat_map(
-        cose_sign.signatures,
-        fn(cose_signature) {
-          when
-            pairs.get_first(cose_signature.headers.protected, hdr_key_id)
-          is {
-            Some(key_data) -> {
-              expect key_bytes: crypto.VerificationKey = key_data
-              [(key_bytes, cose_signature.signature)]
-            }
-            None -> []
-          }
-        },
-      )
-  }
+  let result =
+    builtin.append_bytearray(
+      #"84",
+      builtin.append_bytearray(fixed_content_type_byte, content_bytes),
+    )
+  trace @"serialise_sig_structure result": result
+  result
 }
 
 test single_signature() {
@@ -153,16 +122,14 @@ test single_signature() {
 
   let payload: ByteArray = "Hello, Cardano!"
 
+  // Pre-serialized CBOR: {1: -8, 4: pub_key}
+  let protected_header =
+    #"a20127045820384783f24116d6a337f62e20ec8da898bab5379bc49d1dc7317fa446ee3d40ab"
+
   let signed_message =
     SingleSig(
       COSESign1 {
-        headers: Headers {
-          protected: [
-            Pair(as_data(1), as_data(-8)),
-            Pair(as_data(hdr_key_id), as_data(pub_key)),
-          ],
-          unprotected: [],
-        },
+        headers: Headers { protected: protected_header, unprotected: #"" },
         payload: Some(payload),
         signature,
       },
@@ -182,8 +149,6 @@ test single_signature() {
       signature,
     )
 
-  expect extract_signatures(signed_message) == [(pub_key, signature)]
-
   True
 }
 
@@ -200,29 +165,31 @@ test multi_signature() {
 
   let payload: ByteArray = "Hello, Cardano!"
 
+  // Pre-serialized CBOR: {1: -8, 4: pub_key_1}
+  let protected_header_1 =
+    #"a20127045820f1b2e2a115dc2644c0aa3caca5bdcfbcfc7d3cdea2ee0281bf78f2793286e321"
+
+  // Pre-serialized CBOR: {1: -8, 4: pub_key_2}
+  let protected_header_2 =
+    #"a2012704582008a616a8b390df1211656bfe6690a9ec7cffaec3e5a6e2e5a12a7a93368c7ad6"
+
   let signed_message =
     MultiSig(
       COSESign {
-        headers: Headers { protected: [], unprotected: [] },
+        headers: Headers { protected: #"", unprotected: #"" },
         payload: Some(payload),
         signatures: [
           COSESignature {
             headers: Headers {
-              protected: [
-                Pair(as_data(1), as_data(-8)),
-                Pair(as_data(hdr_key_id), as_data(pub_key_1)),
-              ],
-              unprotected: [],
+              protected: protected_header_1,
+              unprotected: #"",
             },
             signature: signature_1,
           },
           COSESignature {
             headers: Headers {
-              protected: [
-                Pair(as_data(1), as_data(-8)),
-                Pair(as_data(hdr_key_id), as_data(pub_key_2)),
-              ],
-              unprotected: [],
+              protected: protected_header_2,
+              unprotected: #"",
             },
             signature: signature_2,
           },
@@ -251,11 +218,6 @@ test multi_signature() {
       signature_2,
     )
 
-  expect
-    extract_signatures(signed_message) == [
-      (pub_key_1, signature_1), (pub_key_2, signature_2),
-    ]
-
   True
 }
 
@@ -266,15 +228,9 @@ pub fn build_sig_structure_for_sign1(
   headers: Headers,
   payload: ByteArray,
 ) -> SigStructure {
-  let body_protected =
-    if list.length(headers.protected) > 0 {
-      cbor.serialise(headers.protected)
-    } else {
-      #""
-    }
   SigStructure {
     context: "Signature1",
-    body_protected,
+    body_protected: headers.protected,
     external_aad: #"",
     payload,
   }
@@ -287,14 +243,11 @@ test build_sig_structure_for_sign1_test() {
   let signature =
     #"95dad3041fd972ac86eeeb5f462a438b7dca10d7bfc287618e4c5401a3bca6217829e1ee5ca2bfac5f4106ec8f26d6851a7ff8975f1be1dc438ba8b277219800"
 
-  let headers =
-    Headers {
-      protected: [
-        Pair(as_data(1), as_data(-8)),
-        Pair(as_data(hdr_key_id), as_data(pub_key)),
-      ],
-      unprotected: [],
-    }
+  // Pre-serialized CBOR: {1: -8, 4: pub_key}
+  let protected_header =
+    #"a20127045820384783f24116d6a337f62e20ec8da898bab5379bc49d1dc7317fa446ee3d40ab"
+
+  let headers = Headers { protected: protected_header, unprotected: #"" }
 
   let payload: ByteArray = "Hello, Cardano!"
 

--- a/lib/sundae/cose.ak
+++ b/lib/sundae/cose.ak
@@ -78,36 +78,71 @@ pub fn payload(signed_message: SignedMessage) -> ByteArray {
   }
 }
 
+/// Encode a byte array with definite-length CBOR encoding (major type 2).
+/// This produces `40-57` for 0-23 bytes, `58xx` for 24-255 bytes, `59xxxx` for 256-65535 bytes.
+fn encode_bytes_definite(data: ByteArray) -> ByteArray {
+  let len = builtin.length_of_bytearray(data)
+  if len <= 23 {
+    // 40-57: length encoded in lower 5 bits
+    builtin.cons_bytearray(0x40 + len, data)
+  } else if len <= 255 {
+    // 58 xx: 1-byte length prefix
+    builtin.cons_bytearray(0x58, builtin.cons_bytearray(len, data))
+  } else {
+    // 59 xx xx: 2-byte length prefix (big-endian)
+    let hi = len / 256
+    let lo = len % 256
+    builtin.cons_bytearray(
+      0x59,
+      builtin.cons_bytearray(hi, builtin.cons_bytearray(lo, data)),
+    )
+  }
+}
+
+/// Encode a text string with definite-length CBOR encoding (major type 3).
+/// This produces `60-77` for 0-23 chars, `78xx` for 24-255 chars.
+fn encode_text_definite(data: ByteArray) -> ByteArray {
+  let len = builtin.length_of_bytearray(data)
+  if len <= 23 {
+    // 60-77: length encoded in lower 5 bits
+    builtin.cons_bytearray(0x60 + len, data)
+  } else if len <= 255 {
+    // 78 xx: 1-byte length prefix
+    builtin.cons_bytearray(0x78, builtin.cons_bytearray(len, data))
+  } else {
+    // 79 xx xx: 2-byte length prefix (big-endian)
+    let hi = len / 256
+    let lo = len % 256
+    builtin.cons_bytearray(
+      0x79,
+      builtin.cons_bytearray(hi, builtin.cons_bytearray(lo, data)),
+    )
+  }
+}
+
 pub fn serialise_sig_structure(sig_structure: SigStructure) -> ByteArray {
   trace @"SigStructure.context": sig_structure.context
   trace @"SigStructure.body_protected": sig_structure.body_protected
   trace @"SigStructure.external_aad": sig_structure.external_aad
   trace @"SigStructure.payload": sig_structure.payload
 
-  let raw_bytes =
-    cbor.serialise(
-      [
-        sig_structure.context,
-        sig_structure.body_protected,
-        sig_structure.external_aad,
-        sig_structure.payload,
-      ],
-    )
-  trace @"raw_bytes (CBOR serialised)": raw_bytes
-
-  let context_type_byte = builtin.slice_bytearray(1, 1, raw_bytes)
-  let fixed_content_type_byte = builtin.write_bits(context_type_byte, [5], True)
-  let content_bytes =
-    builtin.slice_bytearray(
-      2,
-      builtin.length_of_bytearray(raw_bytes) - 3,
-      raw_bytes,
-    )
+  // Manually construct CBOR with definite-length encoding to match CIP-30 wallets
+  // Format: 84 (4-element array) + context + body_protected + external_aad + payload
+  let context_encoded = encode_text_definite(sig_structure.context)
+  let body_protected_encoded = encode_bytes_definite(sig_structure.body_protected)
+  let external_aad_encoded = encode_bytes_definite(sig_structure.external_aad)
+  let payload_encoded = encode_bytes_definite(sig_structure.payload)
 
   let result =
     builtin.append_bytearray(
       #"84",
-      builtin.append_bytearray(fixed_content_type_byte, content_bytes),
+      builtin.append_bytearray(
+        context_encoded,
+        builtin.append_bytearray(
+          body_protected_encoded,
+          builtin.append_bytearray(external_aad_encoded, payload_encoded),
+        ),
+      ),
     )
   trace @"serialise_sig_structure result": result
   result

--- a/lib/sundae/multisig.ak
+++ b/lib/sundae/multisig.ak
@@ -262,43 +262,86 @@ pub fn satisfied_payloads(
 ) -> Bool {
   when script is {
     Signature { key_hash } -> {
-      expect Some((public_key, signature, payload)) =
+      trace @"Checking Signature for key_hash": key_hash
+      let found =
         list.find(signatures, fn((k, _, _)) { blake2b_224(k) == key_hash })
-      verify_ed25519_signature(public_key, payload, signature)
+      when found is {
+        Some((public_key, signature, payload)) -> {
+          trace @"Found signature, verifying..."
+          let result = verify_ed25519_signature(public_key, payload, signature)
+          trace @"Signature verification result": result
+          result
+        }
+        None -> {
+          trace @"No signature found for key_hash": key_hash
+          False
+        }
+      }
     }
-    AllOf { scripts } ->
-      list.all(
-        scripts,
-        fn(s) { satisfied_payloads(s, signatures, valid_range, withdrawals) },
-      )
-    AnyOf { scripts } ->
-      list.any(
-        scripts,
-        fn(s) { satisfied_payloads(s, signatures, valid_range, withdrawals) },
-      )
-    AtLeast { required, scripts } ->
-      required <= list.count(
-        scripts,
-        fn(s) { satisfied_payloads(s, signatures, valid_range, withdrawals) },
-      )
-    Before { time } ->
-      when valid_range.upper_bound is {
-        IntervalBound { bound_type: Finite(hi), is_inclusive: True } ->
-          hi <= time
-        IntervalBound { bound_type: Finite(hi), is_inclusive: False } ->
-          hi < time
-        _ -> False
-      }
-    After { time } ->
-      when valid_range.lower_bound is {
-        IntervalBound { bound_type: Finite(lo), is_inclusive: True } ->
-          time <= lo
-        IntervalBound { bound_type: Finite(lo), is_inclusive: False } ->
-          time < lo
-        _ -> False
-      }
-    Script { script_hash } ->
-      pairs.has_key(withdrawals, address.Script(script_hash))
+    AllOf { scripts } -> {
+      trace @"Checking AllOf with script count": list.length(scripts)
+      let result =
+        list.all(
+          scripts,
+          fn(s) { satisfied_payloads(s, signatures, valid_range, withdrawals) },
+        )
+      trace @"AllOf result": result
+      result
+    }
+    AnyOf { scripts } -> {
+      trace @"Checking AnyOf with script count": list.length(scripts)
+      let result =
+        list.any(
+          scripts,
+          fn(s) { satisfied_payloads(s, signatures, valid_range, withdrawals) },
+        )
+      trace @"AnyOf result": result
+      result
+    }
+    AtLeast { required, scripts } -> {
+      trace @"Checking AtLeast": required
+      let count =
+        list.count(
+          scripts,
+          fn(s) { satisfied_payloads(s, signatures, valid_range, withdrawals) },
+        )
+      trace @"AtLeast satisfied count": count
+      let result = required <= count
+      trace @"AtLeast result": result
+      result
+    }
+    Before { time } -> {
+      trace @"Checking Before": time
+      let result =
+        when valid_range.upper_bound is {
+          IntervalBound { bound_type: Finite(hi), is_inclusive: True } ->
+            hi <= time
+          IntervalBound { bound_type: Finite(hi), is_inclusive: False } ->
+            hi < time
+          _ -> False
+        }
+      trace @"Before result": result
+      result
+    }
+    After { time } -> {
+      trace @"Checking After": time
+      let result =
+        when valid_range.lower_bound is {
+          IntervalBound { bound_type: Finite(lo), is_inclusive: True } ->
+            time <= lo
+          IntervalBound { bound_type: Finite(lo), is_inclusive: False } ->
+            time < lo
+          _ -> False
+        }
+      trace @"After result": result
+      result
+    }
+    Script { script_hash } -> {
+      trace @"Checking Script": script_hash
+      let result = pairs.has_key(withdrawals, address.Script(script_hash))
+      trace @"Script result": result
+      result
+    }
   }
 }
 

--- a/lib/sundae/multisig.ak
+++ b/lib/sundae/multisig.ak
@@ -268,6 +268,9 @@ pub fn satisfied_payloads(
       when found is {
         Some((public_key, signature, payload)) -> {
           trace @"Found signature, verifying..."
+          trace @"verify_ed25519 public_key": public_key
+          trace @"verify_ed25519 payload": payload
+          trace @"verify_ed25519 signature": signature
           let result = verify_ed25519_signature(public_key, payload, signature)
           trace @"Signature verification result": result
           result

--- a/plutus.json
+++ b/plutus.json
@@ -1,0 +1,14 @@
+{
+  "preamble": {
+    "title": "sundaeswap-finance/aicone",
+    "description": "Aiken contracts for project 'sundaeswap-finance/aicone'",
+    "version": "0.0.0",
+    "plutusVersion": "v3",
+    "compiler": {
+      "name": "Aiken",
+      "version": "v1.1.19+e525483"
+    },
+    "license": "Apache-2.0"
+  },
+  "validators": []
+}


### PR DESCRIPTION
# Changes
- Changed HeaderMap type from Pairs<Data, Data> to ByteArray to accept pre-serialized CBOR headers directly
- Implemented manual definite-length CBOR encoding for SigStructure to match CIP-30 wallet signature format
- Added debug traces throughout signature verification flow for easier troubleshooting

# Reasoning
CIP-30 wallets (like Eternl, Nami, etc.) use definite-length CBOR encoding when signing messages. However, Aiken's built-in cbor.serialise produces indefinite-length encoding. This mismatch caused Ed25519 signature verification to fail because the SigStructure bytes constructed on-chain didn't match what the wallet actually signed.

# Solution
 1. Pre-serialized headers: Instead of deserializing and re-serializing header maps. We now pass headers as raw ByteArray that preserves the original CBOR encoding from the wallet.
  2. Manual CBOR encoding: Added encode_bytes_definite and encode_text_definite helper functions that produce definite-length CBOR, ensuring the SigStructure matches exactly what CIP-30 wallets sign.
  3. Removed extract_signatures: This function is no longer needed since signature/key extraction is now handled differently with the new header format.